### PR TITLE
add handler test examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all

--- a/darpi-middleware/src/auth.rs
+++ b/darpi-middleware/src/auth.rs
@@ -30,8 +30,12 @@ impl Claims {
 /// authorize provides users the ability to control access to certain or all routes
 /// Simply pass it along in the handler macro and provide the #[handler] argument
 ///  `T: UserRole`
-///```rust
-/// #[handler(Container, [authorize(Role::Admin)])]
+///```rust,ignore
+/// #[handler({
+///     middleware: {
+///         request: [authorize(Role::Admin)]
+///     }
+/// })]
 /// async fn do_something() -> String {
 ///     format!("do something")
 /// }
@@ -67,7 +71,7 @@ pub async fn authorize(
 /// UserRole represents user types within an application
 /// to identify access levels
 ///
-/// ```rust, no_run
+/// ```rust, ignore
 /// #[derive(Clone, PartialEq, PartialOrd)]
 /// pub enum Role {
 ///     User,

--- a/darpi-middleware/src/compression.rs
+++ b/darpi-middleware/src/compression.rs
@@ -16,7 +16,7 @@ use std::convert::TryFrom;
 /// if non is found, it will result in a noop
 /// in this example, we can all requests to all handlers will be compressed with gzip
 ///  if the client supports it
-///```rust
+///```rust,ignore
 /// #[tokio::test]
 /// async fn main() -> Result<(), darpi::Error> {
 ///     let address = format!("127.0.0.1:{}", 3000);
@@ -98,7 +98,7 @@ pub async fn compress(
 /// will result in an error response with StatusCode::UNSUPPORTED_MEDIA_TYPE
 /// in this example, all requests to all handlers will be decompressed before
 /// the handler gets invoked
-///```rust
+///```rust,ignore
 /// #[tokio::test]
 /// async fn main() -> Result<(), darpi::Error> {
 ///     let address = format!("127.0.0.1:{}", 3000);

--- a/darpi-middleware/src/lib.rs
+++ b/darpi-middleware/src/lib.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 /// this middleware limits the request body size by a user passed argument
 /// the argument `size` indicates number of bytes
 /// if the body is higher than the specified size, it will result in an error response being sent to the user
-/// ```rust
+/// ```rust, ignore
 /// #[handler([body_size_limit(64)])]
 /// async fn say_hello(#[path] p: Name, #[body] payload: Json<Name>) -> impl Responder {
 ///     format!("{} sends hello to {}", p.name, payload.name)

--- a/darpi-web/src/response.rs
+++ b/darpi-web/src/response.rs
@@ -71,6 +71,24 @@ impl Responder for String {
     }
 }
 
+macro_rules! impl_responder_n {
+    ($($x:ty),* $(,)*) => {
+        $(
+            impl Responder for $x {
+                fn respond(self) -> Response<Body> {
+                    Response::builder()
+                        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                        .status(StatusCode::OK)
+                        .body(Body::from(format!("{}", self)))
+                        .unwrap()
+                }
+            }
+        )*
+    };
+}
+
+impl_responder_n!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+
 impl Responder for () {
     fn respond(self) -> Response<Body> {
         Response::builder()

--- a/examples/test_handler.rs
+++ b/examples/test_handler.rs
@@ -1,0 +1,73 @@
+use darpi::response::ResponderError;
+use darpi::{handler, Args, Body, Handler, Path, Request, StatusCode};
+use derive_more::Display;
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+use std::num::TryFromIntError;
+
+#[tokio::test]
+async fn increment_byte_ok() {
+    use std::sync::Arc;
+    let req = Request::get("http://127.0.0.1:3000/increment_bute/5")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = Handler::call(
+        increment_byte,
+        Args {
+            request: req,
+            container: Arc::new(()),
+            route_args: ("5".to_string(),),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(StatusCode::OK, resp.status());
+}
+
+#[tokio::test]
+async fn increment_byte_not_ok() {
+    use std::sync::Arc;
+    let req = Request::get("http://127.0.0.1:3000/increment_bute/5")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = Handler::call(
+        increment_byte,
+        Args {
+            request: req,
+            container: Arc::new(()),
+            route_args: ("255".to_string(),),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(StatusCode::INTERNAL_SERVER_ERROR, resp.status());
+}
+
+#[derive(Display, Debug)]
+pub enum IncrementError {
+    Overflow,
+    Cast(TryFromIntError),
+}
+
+impl ResponderError for IncrementError {}
+
+#[derive(Deserialize, Serialize, Debug, Path)]
+pub struct Params {
+    n: usize,
+}
+
+#[handler]
+async fn increment_byte(#[path] p: Params) -> Result<u8, IncrementError> {
+    let byte: u8 = p.n.try_into().map_err(|e| IncrementError::Cast(e))?;
+
+    match byte {
+        u8::MAX => Err(IncrementError::Overflow),
+        _ => Ok(byte + 1),
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
implements https://github.com/darpi-rs/darpi/issues/14

No need to add framework support for this. At least, not as of yet.
It's sufficient to add examples.